### PR TITLE
autoset property

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ SELECT F.uniquename as marker_locus_name, F.feature_id as marker_locus_id, F2.un
   
   ```
   
-  2.  Ensure that the featuremap bundle ( IE Genetic Map) has a chado property with the `local:featuremap_type` term.  I reccomend setting a default value for this property so you won't forget.
+  2.  Ensure that the featuremap bundle ( IE Genetic Map) has a chado property with the `local:featuremap_type` term.  I reccommend setting a default value for this property so you won't forget.  **Note** you should only need to set this property yourself if the Tripal Entity you are using was custom created and has no type.
   
   
 If your featuremap has this property set, and you've populated the altered **tripal_map_genetic_markers_mview** materialized view (`Data Storage -> Chado -> Materialized Views`, press "populate"), your field should show up on the organism and featuremap!  You might need to clear the cache (`drush cc all`) before the field appears on the organism.

--- a/includes/TripalImporter/CmapImporter.inc
+++ b/includes/TripalImporter/CmapImporter.inc
@@ -129,8 +129,26 @@ $organism_options = chado_get_organism_select_options(FALSE);
     $typeprop = chado_get_property($record, $property);
 
     if (!$typeprop) {
-      form_set_error('featuremap_id', t('The featuremap you selected does not have the featuremap_type property set and will cause problems with the TripalMap module.  Please set the property.  See the README for more help'));
 
+      //  Set the property to be what the bundle set via rdfs:type.
+
+      $term = chado_get_cvterm(['id' => 'rdfs:type']);
+      $property = ['type_id' => $term->cvterm_id];
+      $bundle_type_prop = chado_get_property($record, $property);
+
+      if (!$bundle_type_prop) {
+
+        form_set_error('featuremap_id', t('The featuremap you selected does not have the featuremap_type property set and will cause problems with the TripalMap module.  We could not auto-set the property based on the bundle.  Please set the property.  See the README for more help.'));
+      }
+      else {
+        $value = [
+          'cv_name' => 'local',
+          'type_name' => 'featuremap_type',
+          'value' => $bundle_type_prop->value
+        ];
+
+        chado_insert_property($record, $value);
+      }
     }
 
     if ($form_state['values']['organism_id'] === 0) {


### PR DESCRIPTION
Automatically add the property the tripalmap module looks for by using the property that tripal uses for the type (`rdfs:type`).

Therefore the user will only need to set the property manually if they are using a "vanilla" featuremap, which tripal doesnt ship with.
